### PR TITLE
add Sports Day event page and site-wide announcement bar and fixed the contact us page

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,12 +1,33 @@
 const express = require("express");
+const mongoose = require("mongoose");
 const cors = require("cors");
 const nodemailer = require("nodemailer");
 require("dotenv").config();
+
+// --- MongoDB Connection ---
+mongoose
+  .connect(process.env.MONGODB_URI)
+  .then(() => console.log("✓ MongoDB connected"))
+  .catch((err) => console.error("✗ MongoDB connection error:", err));
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+// --- Sports Day Signup Schema ---
+const signupSchema = new mongoose.Schema({
+  firstName: { type: String, required: true },
+  lastName: { type: String, required: true },
+  email: { type: String, required: true },
+  phone: { type: String, required: true },
+  gender: { type: String, required: true },
+  activities: { type: [String], required: true },
+  medical: { type: String, default: "" },
+  submittedAt: { type: Date, default: Date.now },
+});
+
+const Signup = mongoose.model("Signup", signupSchema);
 
 // Using church email to send to itself
 const transporter = nodemailer.createTransport({
@@ -216,6 +237,122 @@ app.post("/api/prayer-request", async (req, res) => {
   } catch (error) {
     console.error("Error sending email:", error);
     res.status(500).json({ error: "Failed to send prayer request" });
+  }
+});
+
+// =========================================
+// SPORTS DAY SIGNUP
+// =========================================
+app.post("/api/sports-day-rsvp", async (req, res) => {
+  const { people } = req.body;
+
+  if (!Array.isArray(people) || people.length === 0) {
+    return res.status(400).json({ success: false, message: "No signup data provided" });
+  }
+
+  for (const p of people) {
+    if (!p.firstName || !p.lastName || !p.email || !p.phone || !p.gender || !p.activities?.length) {
+      return res.status(400).json({ success: false, message: "Missing required fields" });
+    }
+  }
+
+  try {
+    // Save to MongoDB
+    await Signup.insertMany(people);
+
+    // Build styled email cards for each person
+    const peopleHtml = people
+      .map(
+        (p, idx) => `
+        <div style="background:#f9f9f9; border-left:4px solid #91772F; padding:18px; border-radius:8px; margin-bottom:14px;">
+          <p style="margin:0 0 10px; color:#1F1591; font-size:16px; font-weight:bold;">
+            Person ${idx + 1}: ${p.firstName} ${p.lastName}
+          </p>
+          <table style="width:100%; border-collapse:collapse; font-size:14px; color:#333;">
+            <tr>
+              <td style="padding:4px 0; font-weight:bold; width:130px;">Email</td>
+              <td style="padding:4px 0;"><a href="mailto:${p.email}" style="color:#1F1591; text-decoration:none;">${p.email}</a></td>
+            </tr>
+            <tr>
+              <td style="padding:4px 0; font-weight:bold;">Phone</td>
+              <td style="padding:4px 0;">${p.phone}</td>
+            </tr>
+            <tr>
+              <td style="padding:4px 0; font-weight:bold;">Gender</td>
+              <td style="padding:4px 0;">${p.gender}</td>
+            </tr>
+            <tr>
+              <td style="padding:4px 0; font-weight:bold; vertical-align:top;">Activities</td>
+              <td style="padding:4px 0;">${p.activities.join(", ")}</td>
+            </tr>
+            <tr>
+              <td style="padding:4px 0; font-weight:bold; vertical-align:top;">Medical</td>
+              <td style="padding:4px 0;">${p.medical || "None"}</td>
+            </tr>
+          </table>
+        </div>
+      `
+      )
+      .join("");
+
+    const mailOptions = {
+      from: `"Partakers Sports Day" <${process.env.EMAIL_USER}>`,
+      to: process.env.EMAIL_USER,
+      subject: `🏃 Sports Day Sign Up - ${people[0].firstName} ${people[0].lastName}${
+        people.length > 1 ? ` +${people.length - 1} more` : ""
+      }`,
+      html: `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <style>
+            body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin:0; padding:0; background-color:#f5f5f5; }
+            .container { max-width:600px; margin:20px auto; background:white; border-radius:10px; overflow:hidden; box-shadow:0 2px 10px rgba(0,0,0,0.1); }
+            .header { background:linear-gradient(135deg, #1F1591 0%, #742F8D 50%, #1D4C80 100%); color:white; padding:30px 20px; text-align:center; }
+            .header h1 { margin:0; font-size:22px; font-weight:bold; }
+            .header p { margin:8px 0 0; opacity:0.9; font-size:14px; }
+            .content { padding:25px; }
+            .summary { background:#E4CFB2; padding:12px 16px; border-radius:6px; font-size:14px; color:#5C4A1A; margin-bottom:20px; font-weight:600; }
+            .footer { text-align:center; color:#666; font-size:12px; padding:20px; background:#f9f9f9; border-top:1px solid #eee; }
+          </style>
+        </head>
+        <body>
+          <div class="container">
+            <div class="header">
+              <h1>🏃 New Sports Day Sign Up</h1>
+              <p>Received from Partakers Manchester Website</p>
+            </div>
+            <div class="content">
+              <div class="summary">
+                ${people.length} ${people.length === 1 ? "person has" : "people have"} signed up
+              </div>
+              ${peopleHtml}
+            </div>
+            <div class="footer">
+              <p>This sign up was submitted through the Partakers Manchester website</p>
+            </div>
+          </div>
+        </body>
+        </html>
+      `,
+    };
+
+    await transporter.sendMail(mailOptions);
+
+    res.status(200).json({ success: true, message: "Sign up received successfully" });
+  } catch (error) {
+    console.error("Error:", error);
+    res.status(500).json({ success: false, message: "Failed to process sign up" });
+  }
+});
+
+// View all signups (protect this route in production!)
+app.get("/api/sports-day-rsvp", async (req, res) => {
+  try {
+    const all = await Signup.find().sort({ submittedAt: -1 });
+    res.json(all);
+  } catch (error) {
+    res.status(500).json({ success: false, message: "Failed to fetch signups" });
   }
 });
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,10 +12,41 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "mongoose": "^9.7.4",
         "nodemailer": "^7.0.12"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/accepts": {
@@ -111,6 +142,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bson": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/bytes": {
@@ -673,6 +713,15 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/kareem": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
+      "integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -690,6 +739,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -739,6 +794,105 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
+      "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+      "integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.7.4.tgz",
+      "integrity": "sha512-nuSYGUWWzNd4EAbGYxE469wPTL+kmxb5+91YvCvMkJ08rvNRht/usZUU3LuFuk7rDutF2QWBZHPHuzM8TxXApA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "kareem": "3.3.0",
+        "mongodb": "~7.2",
+        "mpath": "0.9.0",
+        "mquery": "6.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/ms": {
@@ -897,6 +1051,15 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.1",
@@ -1108,6 +1271,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1119,6 +1288,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/statuses": {
@@ -1175,6 +1353,18 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1212,6 +1402,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "mongoose": "^9.7.4",
     "nodemailer": "^7.0.12"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Home from './pages/Home.jsx'
 import About from './pages/About.jsx'
 import Connect from './pages/Connect.jsx'
 import ContactUs from './pages/ContactUs.jsx';
+import SportsDay from './pages/events/SportsDay.jsx';
 
 
 function App() {
@@ -26,7 +27,8 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />
           <Route path="/connect" element={<Connect />} />
-          <Route path="/contact-us" element={<ContactUs />} />
+          <Route path="/contact" element={<ContactUs />} />
+          <Route path="/events/sports-day" element={<SportsDay />} />
         </Routes>
       </main>
       <Footer />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,12 +14,15 @@ import About from './pages/About.jsx'
 import Connect from './pages/Connect.jsx'
 import ContactUs from './pages/ContactUs.jsx';
 import SportsDay from './pages/events/SportsDay.jsx';
+import EventsPage from './pages/events/EventsPage.jsx';
+import AnnouncementBar from './components/AnnouncementBar.jsx';
 
 
 function App() {
 
   return (
     <div className="min-h-screen flex flex-col bg-black">
+      <AnnouncementBar />
       <Navbar />
       <Analytics />
       <main className="grow">
@@ -29,6 +32,7 @@ function App() {
           <Route path="/connect" element={<Connect />} />
           <Route path="/contact" element={<ContactUs />} />
           <Route path="/events/sports-day" element={<SportsDay />} />
+          <Route path="/events" element={<EventsPage />} />
         </Routes>
       </main>
       <Footer />

--- a/frontend/src/components/AnnouncementBar.jsx
+++ b/frontend/src/components/AnnouncementBar.jsx
@@ -1,0 +1,41 @@
+// AnnouncementBar.jsx
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+function AnnouncementBar() {
+  const navigate = useNavigate();
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) return null;
+
+  const fontQuicksand = { fontFamily: "'Quicksand', sans-serif" };
+
+  return (
+    <div className="bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-2 flex items-center justify-center gap-2 sm:gap-3 relative">
+        <p
+          className="text-white text-xs sm:text-sm font-semibold text-center pr-6"
+          style={fontQuicksand}
+        >
+          🥾 Registration for our Sports Day is now open!{" "}
+          <button
+            onClick={() => navigate("/events/sports-day")}
+            className="underline font-bold hover:text-[#E4CFB2] transition-colors"
+          >
+            Register Now →
+          </button>
+        </p>
+
+        <button
+          onClick={() => setVisible(false)}
+          className="absolute right-3 sm:right-4 text-white/70 hover:text-white transition-colors text-lg leading-none"
+          aria-label="Dismiss announcement"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AnnouncementBar;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -13,7 +13,7 @@ function Navbar() {
     { path: "/", label: "Home" },
     { path: "/about", label: "Who We Are" },
     { path: "/connect", label: "Visit Us" },
-    { path: "/contact-us", label: "Get In Touch" },
+    { path: "/contact", label: "Get In Touch" },
   ];
 
   const isActive = (path) => {

--- a/frontend/src/pages/events/EventsPage.jsx
+++ b/frontend/src/pages/events/EventsPage.jsx
@@ -1,0 +1,119 @@
+// Events.jsx - Upcoming Events Listing
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+function Events() {
+  const navigate = useNavigate();
+
+  // 🔧 Add real events here as they come up. Leave empty array for empty state.
+  const events = [
+    // {
+    //   slug: "sports-day",
+    //   title: "Sports Day",
+    //   tagline: "A short, exciting tagline about the event",
+    //   date: "Saturday, [Month] [Day], 2026",
+    //   time: "12:00 PM - 4:00 PM",
+    //   location: "Precious House",
+    //   image: "/src/assets/events/sports-day.jpg",
+    // },
+  ];
+
+  const fontLeague = { fontFamily: "'League Spartan', sans-serif" };
+  const fontQuicksand = { fontFamily: "'Quicksand', sans-serif" };
+
+  return (
+    <div className="bg-white overflow-x-hidden">
+      {/* Hero Section */}
+      <section className="bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80] py-12 sm:py-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 text-center">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2" style={fontLeague}>
+            Upcoming Events
+          </h1>
+          <p className="text-base sm:text-lg text-[#E4CFB2]" style={fontQuicksand}>
+            Come do life with us
+          </p>
+        </div>
+      </section>
+
+      {/* Events List */}
+      <section className="py-12 sm:py-16 bg-white">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          {events.length === 0 ? (
+            <div className="text-center py-12 sm:py-16">
+              <div className="w-16 h-16 sm:w-20 sm:h-20 bg-[#E4CFB2]/40 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg className="w-8 h-8 sm:w-10 sm:h-10 text-[#91772F]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <p className="text-gray-700 text-base sm:text-lg font-semibold mb-1" style={fontLeague}>
+                No events scheduled right now
+              </p>
+              <p className="text-gray-500 text-sm sm:text-base" style={fontQuicksand}>
+                Check back soon, or follow us on social media for updates!
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 sm:gap-6">
+              {events.map((event, idx) => (
+                <div
+                  key={idx}
+                  onClick={() => navigate(`/events/${event.slug}`)}
+                  className="group cursor-pointer bg-white border-2 border-gray-100 rounded-xl overflow-hidden hover:border-[#91772F] hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+                >
+                  {/* Image */}
+                  <div className="relative h-48 sm:h-52 overflow-hidden">
+                    <img
+                      src={event.image}
+                      alt={event.title}
+                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
+                    <div className="absolute bottom-3 left-3">
+                      <span
+                        className="inline-block bg-[#91772F] text-white px-3 py-1 rounded-full text-xs font-bold"
+                        style={fontQuicksand}
+                      >
+                        {event.date}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Content */}
+                  <div className="p-5">
+                    <h3 className="text-lg sm:text-xl font-bold text-[#1F1591] mb-1" style={fontLeague}>
+                      {event.title}
+                    </h3>
+                    <p className="text-xs sm:text-sm text-gray-600 mb-3" style={fontQuicksand}>
+                      {event.tagline}
+                    </p>
+                    <div className="flex items-center gap-1.5 text-xs sm:text-sm text-gray-500 mb-1" style={fontQuicksand}>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      {event.time}
+                    </div>
+                    <div className="flex items-center gap-1.5 text-xs sm:text-sm text-gray-500" style={fontQuicksand}>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                      {event.location}
+                    </div>
+                    <span
+                      className="inline-block mt-4 text-[#742F8D] font-semibold text-xs sm:text-sm group-hover:underline"
+                      style={fontQuicksand}
+                    >
+                      View Details →
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Events;

--- a/frontend/src/pages/events/SportsDay.jsx
+++ b/frontend/src/pages/events/SportsDay.jsx
@@ -1,0 +1,363 @@
+// SportsDay.jsx - Sports Day Event Page
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+function SportsDay() {
+  const navigate = useNavigate();
+  const [rsvp, setRsvp] = useState({
+    name: "",
+    email: "",
+    guests: "1",
+    message: "",
+  });
+  const [submitStatus, setSubmitStatus] = useState("");
+  const [error, setError] = useState("");
+
+  // 🔧 PLACEHOLDER: Replace with real Sports Day details
+  const event = {
+    title: "Sports Day",
+    tagline: "A short, exciting tagline about the event",
+    date: "Saturday, [Month] [Day], 2026",
+    time: "12:00 PM - 4:00 PM",
+    location: "Precious House",
+    address: "6 Harthill Street, Manchester M8 8AG",
+    description:
+      "Write a short paragraph describing what Sports Day is about, who it's for, and why people should come. Keep it warm, inviting, and clear.",
+    image: "/src/assets/events/sports-day.jpg", // replace with real image
+  };
+
+  const handleRsvpSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitStatus("sending");
+    setError("");
+
+    try {
+      const response = await fetch("http://localhost:5000/api/event-rsvp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...rsvp, event: event.title }),
+      });
+
+      if (response.ok) {
+        setSubmitStatus("sent");
+        setRsvp({ name: "", email: "", guests: "1", message: "" });
+        setTimeout(() => setSubmitStatus(""), 3000);
+      } else {
+        throw new Error("Failed to send RSVP");
+      }
+    } catch (err) {
+      setError("Failed to send. Please try again or email us directly.");
+      setSubmitStatus("");
+    }
+  };
+
+  const fontLeague = { fontFamily: "'League Spartan', sans-serif" };
+  const fontQuicksand = { fontFamily: "'Quicksand', sans-serif" };
+
+  return (
+    <div className="bg-white overflow-x-hidden">
+      {/* Hero Section */}
+      <section className="relative py-14 sm:py-16 md:py-20 overflow-hidden">
+        <div className="absolute inset-0">
+          <img
+            src={event.image}
+            alt={event.title}
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-br from-[#1F1591]/95 via-[#742F8D]/90 to-[#1D4C80]/95"></div>
+        </div>
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 text-center">
+          <span
+            className="inline-block bg-[#91772F] text-white px-4 py-1.5 rounded-full text-xs sm:text-sm font-bold mb-4"
+            style={fontQuicksand}
+          >
+            Upcoming Event
+          </span>
+          <h1
+            className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2"
+            style={fontLeague}
+          >
+            {event.title}
+          </h1>
+          <p
+            className="text-sm sm:text-base md:text-lg text-[#E4CFB2]"
+            style={fontQuicksand}
+          >
+            {event.tagline}
+          </p>
+        </div>
+      </section>
+
+      {/* Event Details */}
+      <section className="py-8 sm:py-10 md:py-12 bg-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+            {/* Date */}
+            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
+              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <h3
+                className="text-sm font-bold text-[#1F1591] mb-1"
+                style={fontLeague}
+              >
+                Date
+              </h3>
+              <p
+                className="text-xs sm:text-sm text-gray-700"
+                style={fontQuicksand}
+              >
+                {event.date}
+              </p>
+            </div>
+
+            {/* Time */}
+            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
+              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              <h3
+                className="text-sm font-bold text-[#1F1591] mb-1"
+                style={fontLeague}
+              >
+                Time
+              </h3>
+              <p
+                className="text-xs sm:text-sm text-gray-700"
+                style={fontQuicksand}
+              >
+                {event.time}
+              </p>
+            </div>
+
+            {/* Location */}
+            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
+              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+              </div>
+              <h3
+                className="text-sm font-bold text-[#1F1591] mb-1"
+                style={fontLeague}
+              >
+                Location
+              </h3>
+              <p
+                className="text-xs sm:text-sm text-gray-700"
+                style={fontQuicksand}
+              >
+                {event.location}
+              </p>
+              <p className="text-xs text-gray-500" style={fontQuicksand}>
+                {event.address}
+              </p>
+            </div>
+          </div>
+
+          {/* Description */}
+          <div className="bg-gray-50 border-2 border-gray-100 rounded-xl p-5 sm:p-6">
+            <h2
+              className="text-xl sm:text-2xl font-bold text-[#1F1591] mb-3"
+              style={fontLeague}
+            >
+              About This Event
+            </h2>
+            <p
+              className="text-sm sm:text-base text-gray-700 leading-relaxed"
+              style={fontQuicksand}
+            >
+              {event.description}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* RSVP Form */}
+      <section className="py-8 sm:py-10 md:py-12 bg-gradient-to-b from-gray-50 to-white">
+        <div className="max-w-2xl mx-auto px-4 sm:px-6">
+          <div className="text-center mb-6">
+            <h2
+              className="text-xl sm:text-2xl md:text-3xl font-bold text-[#1F1591] mb-2"
+              style={fontLeague}
+            >
+              Reserve Your Spot
+            </h2>
+            <p
+              className="text-sm sm:text-base text-gray-600"
+              style={fontQuicksand}
+            >
+              Let us know you're coming!
+            </p>
+          </div>
+
+          <form
+            onSubmit={handleRsvpSubmit}
+            className="bg-white border-2 border-gray-100 rounded-xl p-5 sm:p-6 hover:border-[#91772F] transition-all duration-300"
+          >
+            <div className="mb-4">
+              <label
+                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
+                style={fontQuicksand}
+              >
+                Your Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                required
+                value={rsvp.name}
+                onChange={(e) => setRsvp({ ...rsvp, name: e.target.value })}
+                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                style={fontQuicksand}
+                placeholder="Enter your name"
+              />
+            </div>
+
+            <div className="mb-4">
+              <label
+                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
+                style={fontQuicksand}
+              >
+                Your Email <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="email"
+                required
+                value={rsvp.email}
+                onChange={(e) => setRsvp({ ...rsvp, email: e.target.value })}
+                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                style={fontQuicksand}
+                placeholder="your@email.com"
+              />
+            </div>
+
+            <div className="mb-4">
+              <label
+                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
+                style={fontQuicksand}
+              >
+                Number of Guests
+              </label>
+              <select
+                value={rsvp.guests}
+                onChange={(e) => setRsvp({ ...rsvp, guests: e.target.value })}
+                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                style={fontQuicksand}
+              >
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <option key={n} value={n}>
+                    {n} {n === 1 ? "person" : "people"}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="mb-5">
+              <label
+                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
+                style={fontQuicksand}
+              >
+                Message{" "}
+                <span className="text-gray-400 font-normal">(Optional)</span>
+              </label>
+              <textarea
+                value={rsvp.message}
+                onChange={(e) => setRsvp({ ...rsvp, message: e.target.value })}
+                rows="3"
+                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors resize-none"
+                style={fontQuicksand}
+                placeholder="Any questions or dietary requirements?"
+              />
+            </div>
+
+            {error && (
+              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+                <p
+                  className="text-red-600 text-xs sm:text-sm"
+                  style={fontQuicksand}
+                >
+                  {error}
+                </p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitStatus === "sending"}
+              className="w-full bg-gradient-to-r from-[#1F1591] to-[#742F8D] text-white px-6 py-3 rounded-lg font-bold text-sm sm:text-base transition-all duration-300 hover:shadow-lg hover:scale-105 disabled:opacity-50"
+              style={fontQuicksand}
+            >
+              {submitStatus === "sending"
+                ? "Sending..."
+                : submitStatus === "sent"
+                  ? "RSVP Sent! ✓"
+                  : "RSVP Now"}
+            </button>
+          </form>
+        </div>
+      </section>
+
+      {/* Back to Home */}
+      <section className="py-8 sm:py-10 bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80]">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+          <h2
+            className="text-lg sm:text-xl font-bold text-white mb-3"
+            style={fontLeague}
+          >
+            Can't wait to see you there!
+          </h2>
+          <button
+            onClick={() => navigate("/")}
+            className="bg-[#91772F] text-white hover:bg-[#91772F]/90 px-6 py-2.5 rounded-full font-bold text-sm transition-all duration-300 hover:scale-105 shadow-lg"
+            style={fontQuicksand}
+          >
+            Back to Home
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default SportsDay;

--- a/frontend/src/pages/events/SportsDay.jsx
+++ b/frontend/src/pages/events/SportsDay.jsx
@@ -1,52 +1,120 @@
-// SportsDay.jsx - Sports Day Event Page
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+const ACTIVITIES = [
+  "Men's 100m",
+  "Women's 100m",
+  "Men's 200m",
+  "Women's 200m",
+  "Mixed 4x400 Relay",
+  "Mixed 4x100 Relay",
+  "Egg and Spoon Race",
+  "Three Legged Race",
+  "Tug of War",
+  "Shot Put",
+  "Mini Badminton",
+  "Spectator (Just Watching)",
+];
+
 function SportsDay() {
   const navigate = useNavigate();
-  const [rsvp, setRsvp] = useState({
-    name: "",
+
+  const event = {
+    title: "Sports Day",
+    tagline: "Our First Ever Partakers Sports Day!",
+    date: "Saturday, July 25th, 2026", // 🔧 update
+    time: "11:00 AM - 5:30 PM", // 🔧 confirm/update
+    location: "Cleavley Athletics Track",
+    address: "Winton, Blantyre St, Eccles, Manchester M30 8HY",
+    mapsUrl: "https://share.google/uReexCLeARwnV3EPa",
+    description:
+      "This is our very first Partakers Sports Day, and we can't wait to celebrate it with you! We've got a full day of activities lined up, from races to relays to just-for-fun games, so there's something for everyone whether you're competing or cheering from the sidelines. More than anything, it's a chance for us to come together as a community, meet new people, laugh a lot, and fellowship in Christ outside the four walls of church. Come as you are and bring a friend!",
+  };
+
+  const emptyPerson = {
+    firstName: "",
+    lastName: "",
     email: "",
-    guests: "1",
-    message: "",
-  });
+    phone: "",
+    gender: "",
+    activities: [],
+    medical: "",
+  };
+
+  const [people, setPeople] = useState([{ ...emptyPerson }]);
+  const [activePersonIndex, setActivePersonIndex] = useState(0);
+  const [dataProtectionAccepted, setDataProtectionAccepted] = useState(false);
+  const [showDataProtection, setShowDataProtection] = useState(false);
   const [submitStatus, setSubmitStatus] = useState("");
   const [error, setError] = useState("");
 
-  // 🔧 PLACEHOLDER: Replace with real Sports Day details
-  const event = {
-    title: "Sports Day",
-    tagline: "A short, exciting tagline about the event",
-    date: "Saturday, [Month] [Day], 2026",
-    time: "12:00 PM - 4:00 PM",
-    location: "Precious House",
-    address: "6 Harthill Street, Manchester M8 8AG",
-    description:
-      "Write a short paragraph describing what Sports Day is about, who it's for, and why people should come. Keep it warm, inviting, and clear.",
-    image: "/src/assets/events/sports-day.jpg", // replace with real image
+  const updatePerson = (index, field, value) => {
+    const updated = [...people];
+    updated[index][field] = value;
+    setPeople(updated);
   };
 
-  const handleRsvpSubmit = async (e) => {
+  const toggleActivity = (index, activity) => {
+    const updated = [...people];
+    const current = updated[index].activities;
+    updated[index].activities = current.includes(activity)
+      ? current.filter((a) => a !== activity)
+      : [...current, activity];
+    setPeople(updated);
+  };
+
+  const addPerson = () => {
+    setPeople([...people, { ...emptyPerson }]);
+    setActivePersonIndex(people.length);
+  };
+
+  const removePerson = (index) => {
+    if (people.length === 1) return;
+    const updated = people.filter((_, i) => i !== index);
+    setPeople(updated);
+    setActivePersonIndex(Math.max(0, index - 1));
+  };
+
+  const isPersonComplete = (p) =>
+    p.firstName && p.lastName && p.email && p.phone && p.gender && p.activities.length > 0;
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    setSubmitStatus("sending");
     setError("");
 
+    if (!dataProtectionAccepted) {
+      setError("Please accept the Data Protection Statement to continue.");
+      return;
+    }
+
+    const incomplete = people.some((p) => !isPersonComplete(p));
+    if (incomplete) {
+      setError("Please complete all required fields and select at least one activity for each person.");
+      return;
+    }
+
+    setSubmitStatus("sending");
+
     try {
-      const response = await fetch("http://localhost:5000/api/event-rsvp", {
+      const response = await fetch("http://localhost:5000/api/sports-day-rsvp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...rsvp, event: event.title }),
+        body: JSON.stringify({ people }),
       });
 
       if (response.ok) {
         setSubmitStatus("sent");
-        setRsvp({ name: "", email: "", guests: "1", message: "" });
-        setTimeout(() => setSubmitStatus(""), 3000);
+        setTimeout(() => {
+          setPeople([{ ...emptyPerson }]);
+          setActivePersonIndex(0);
+          setDataProtectionAccepted(false);
+          setSubmitStatus("");
+        }, 2500);
       } else {
-        throw new Error("Failed to send RSVP");
+        throw new Error("Failed to submit");
       }
     } catch (err) {
-      setError("Failed to send. Please try again or email us directly.");
+      setError("Something went wrong. Please try again or contact us directly.");
       setSubmitStatus("");
     }
   };
@@ -54,297 +122,388 @@ function SportsDay() {
   const fontLeague = { fontFamily: "'League Spartan', sans-serif" };
   const fontQuicksand = { fontFamily: "'Quicksand', sans-serif" };
 
+  const p = people[activePersonIndex];
+  const i = activePersonIndex;
+
   return (
     <div className="bg-white overflow-x-hidden">
-      {/* Hero Section */}
-      <section className="relative py-14 sm:py-16 md:py-20 overflow-hidden">
-        <div className="absolute inset-0">
-          <img
-            src={event.image}
-            alt={event.title}
-            className="w-full h-full object-cover"
-          />
-          <div className="absolute inset-0 bg-gradient-to-br from-[#1F1591]/95 via-[#742F8D]/90 to-[#1D4C80]/95"></div>
-        </div>
-
-        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 text-center">
-          <span
-            className="inline-block bg-[#91772F] text-white px-4 py-1.5 rounded-full text-xs sm:text-sm font-bold mb-4"
-            style={fontQuicksand}
-          >
-            Upcoming Event
-          </span>
-          <h1
-            className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2"
-            style={fontLeague}
-          >
+      {/* Hero */}
+      <section className="bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80] py-8 sm:py-12 md:py-14 animate-[fadeIn_0.6s_ease-out]">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+          <h1 className="text-2xl sm:text-4xl md:text-5xl font-bold text-white mb-2" style={fontLeague}>
             {event.title}
           </h1>
-          <p
-            className="text-sm sm:text-base md:text-lg text-[#E4CFB2]"
-            style={fontQuicksand}
-          >
+          <p className="text-sm sm:text-base text-[#E4CFB2] max-w-2xl mx-auto" style={fontQuicksand}>
             {event.tagline}
           </p>
         </div>
       </section>
 
-      {/* Event Details */}
-      <section className="py-8 sm:py-10 md:py-12 bg-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-            {/* Date */}
-            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-              <h3
-                className="text-sm font-bold text-[#1F1591] mb-1"
-                style={fontLeague}
-              >
-                Date
-              </h3>
-              <p
-                className="text-xs sm:text-sm text-gray-700"
-                style={fontQuicksand}
-              >
-                {event.date}
-              </p>
+      {/* Key Details - Highlighted, bolder */}
+      <section className="py-5 sm:py-8 bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6">
+          <div className="bg-gradient-to-br from-[#1F1591]/5 to-[#742F8D]/5 border-2 border-[#91772F]/30 rounded-xl p-4 sm:p-5 flex flex-col sm:flex-row gap-3 sm:gap-5 items-center sm:items-start transition-all duration-300 hover:border-[#91772F]/60 hover:shadow-md">
+            <div className="w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-xl flex flex-col items-center justify-center text-white flex-shrink-0">
+              <span className="text-[10px] font-bold uppercase" style={fontQuicksand}>Sat</span>
+              <span className="text-xl font-black leading-none" style={fontLeague}>25</span>
+              <span className="text-[10px] font-bold uppercase" style={fontQuicksand}>July</span>
             </div>
 
-            {/* Time */}
-            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <h3
-                className="text-sm font-bold text-[#1F1591] mb-1"
-                style={fontLeague}
-              >
-                Time
-              </h3>
-              <p
-                className="text-xs sm:text-sm text-gray-700"
+            <div className="space-y-2 text-sm w-full text-center sm:text-left">
+              <p className="text-gray-900 font-black text-lg sm:text-xl" style={fontLeague}>{event.date}</p>
+              <p className="text-[#742F8D] font-black text-base sm:text-lg" style={fontLeague}>{event.time}</p>
+              <p className="text-gray-800 font-bold text-sm sm:text-base" style={fontQuicksand}>
+                {event.location} — {event.address}
+              </p>
+              <a
+                href={event.mapsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block mt-2 bg-gradient-to-r from-[#1F1591] to-[#742F8D] text-white px-4 py-2 rounded-lg text-xs sm:text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-300"
                 style={fontQuicksand}
               >
-                {event.time}
-              </p>
+                View on Google Maps →
+              </a>
             </div>
-
-            {/* Location */}
-            <div className="bg-white border-2 border-gray-100 rounded-xl p-4 sm:p-5 text-center hover:border-[#91772F] hover:shadow-lg transition-all duration-300">
-              <div className="w-12 h-12 bg-gradient-to-br from-[#1F1591] to-[#742F8D] rounded-lg flex items-center justify-center text-white mx-auto mb-3">
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </div>
-              <h3
-                className="text-sm font-bold text-[#1F1591] mb-1"
-                style={fontLeague}
-              >
-                Location
-              </h3>
-              <p
-                className="text-xs sm:text-sm text-gray-700"
-                style={fontQuicksand}
-              >
-                {event.location}
-              </p>
-              <p className="text-xs text-gray-500" style={fontQuicksand}>
-                {event.address}
-              </p>
-            </div>
-          </div>
-
-          {/* Description */}
-          <div className="bg-gray-50 border-2 border-gray-100 rounded-xl p-5 sm:p-6">
-            <h2
-              className="text-xl sm:text-2xl font-bold text-[#1F1591] mb-3"
-              style={fontLeague}
-            >
-              About This Event
-            </h2>
-            <p
-              className="text-sm sm:text-base text-gray-700 leading-relaxed"
-              style={fontQuicksand}
-            >
-              {event.description}
-            </p>
           </div>
         </div>
       </section>
 
-      {/* RSVP Form */}
-      <section className="py-8 sm:py-10 md:py-12 bg-gradient-to-b from-gray-50 to-white">
-        <div className="max-w-2xl mx-auto px-4 sm:px-6">
-          <div className="text-center mb-6">
-            <h2
-              className="text-xl sm:text-2xl md:text-3xl font-bold text-[#1F1591] mb-2"
-              style={fontLeague}
-            >
-              Reserve Your Spot
-            </h2>
-            <p
-              className="text-sm sm:text-base text-gray-600"
-              style={fontQuicksand}
-            >
-              Let us know you're coming!
-            </p>
+      {/* About + Activities */}
+      <section className="pb-5 sm:pb-8 bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6">
+          <div className="bg-white border-2 border-gray-100 rounded-xl overflow-hidden transition-all duration-300 hover:border-[#91772F]/40">
+            <div className="p-4 sm:p-6 space-y-4">
+              <p className="text-gray-700 text-sm sm:text-base leading-relaxed" style={fontQuicksand}>
+                {event.description}
+              </p>
+
+              <div>
+                <p className="text-gray-900 font-bold text-sm sm:text-base mb-2" style={fontQuicksand}>
+                  Activities on the day
+                </p>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5 sm:gap-2">
+                  {ACTIVITIES.filter((a) => a !== "Spectator (Just Watching)").map((activity, idx) => (
+                    <div
+                      key={idx}
+                      className="flex items-center gap-1.5 bg-[#E4CFB2]/30 rounded-lg px-2.5 py-1.5 transition-transform duration-200 hover:scale-[1.03]"
+                    >
+                      <span className="text-[#742F8D] text-xs">●</span>
+                      <span className="text-gray-800 font-semibold text-xs sm:text-sm" style={fontQuicksand}>{activity}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
+        </div>
+      </section>
 
-          <form
-            onSubmit={handleRsvpSubmit}
-            className="bg-white border-2 border-gray-100 rounded-xl p-5 sm:p-6 hover:border-[#91772F] transition-all duration-300"
-          >
-            <div className="mb-4">
-              <label
-                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
-                style={fontQuicksand}
-              >
-                Your Name <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="text"
-                required
-                value={rsvp.name}
-                onChange={(e) => setRsvp({ ...rsvp, name: e.target.value })}
-                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
-                style={fontQuicksand}
-                placeholder="Enter your name"
-              />
+      {/* Sign Up */}
+      <section className="pb-10 sm:pb-14 bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6">
+          <div className="bg-white border-2 border-[#91772F]/40 rounded-xl overflow-hidden shadow-sm">
+            <div className="border-b-2 border-gray-100 px-4 sm:px-6 py-3 bg-gradient-to-r from-[#1F1591]/5 to-transparent">
+              <h2 className="text-base sm:text-lg font-bold text-[#1F1591]" style={fontLeague}>Sign Up</h2>
             </div>
 
-            <div className="mb-4">
-              <label
-                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
-                style={fontQuicksand}
-              >
-                Your Email <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="email"
-                required
-                value={rsvp.email}
-                onChange={(e) => setRsvp({ ...rsvp, email: e.target.value })}
-                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
-                style={fontQuicksand}
-                placeholder="your@email.com"
-              />
-            </div>
+            <form onSubmit={handleSubmit} className="p-4 sm:p-6">
+              {people.length > 1 && (
+                <div className="mb-4">
+                  <p className="text-xs font-bold text-gray-500 uppercase mb-2 tracking-wide" style={fontQuicksand}>
+                    Signing up {people.length} people — tap to edit
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {people.map((person, idx) => (
+                      <div
+                        key={idx}
+                        className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-xs sm:text-sm font-bold cursor-pointer transition-all duration-200 ${
+                          idx === activePersonIndex
+                            ? "bg-[#1F1591] text-white scale-105 shadow-md"
+                            : isPersonComplete(person)
+                            ? "bg-[#E4CFB2]/60 text-[#5C4A1A] hover:bg-[#E4CFB2]"
+                            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        }`}
+                        style={fontQuicksand}
+                        onClick={() => setActivePersonIndex(idx)}
+                      >
+                        <span>
+                          Person {idx + 1}
+                          {person.firstName ? `: ${person.firstName}` : ""}
+                          {isPersonComplete(person) ? " ✓" : ""}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            removePerson(idx);
+                          }}
+                          className="hover:text-red-400 font-normal"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
-            <div className="mb-4">
-              <label
-                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
-                style={fontQuicksand}
-              >
-                Number of Guests
-              </label>
-              <select
-                value={rsvp.guests}
-                onChange={(e) => setRsvp({ ...rsvp, guests: e.target.value })}
-                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
-                style={fontQuicksand}
-              >
-                {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n}>
-                    {n} {n === 1 ? "person" : "people"}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="mb-5">
-              <label
-                className="block text-gray-700 font-semibold mb-1.5 text-xs sm:text-sm"
-                style={fontQuicksand}
-              >
-                Message{" "}
-                <span className="text-gray-400 font-normal">(Optional)</span>
-              </label>
-              <textarea
-                value={rsvp.message}
-                onChange={(e) => setRsvp({ ...rsvp, message: e.target.value })}
-                rows="3"
-                className="w-full px-3 py-2 sm:px-4 sm:py-3 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors resize-none"
-                style={fontQuicksand}
-                placeholder="Any questions or dietary requirements?"
-              />
-            </div>
-
-            {error && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
-                <p
-                  className="text-red-600 text-xs sm:text-sm"
-                  style={fontQuicksand}
-                >
-                  {error}
+              <div className="mb-4 pb-3 border-b border-gray-100">
+                <p className="text-sm font-bold text-[#742F8D]" style={fontQuicksand}>
+                  {people.length > 1 ? `Now filling in: Person ${activePersonIndex + 1}` : "Your Details"}
                 </p>
               </div>
-            )}
 
-            <button
-              type="submit"
-              disabled={submitStatus === "sending"}
-              className="w-full bg-gradient-to-r from-[#1F1591] to-[#742F8D] text-white px-6 py-3 rounded-lg font-bold text-sm sm:text-base transition-all duration-300 hover:shadow-lg hover:scale-105 disabled:opacity-50"
-              style={fontQuicksand}
-            >
-              {submitStatus === "sending"
-                ? "Sending..."
-                : submitStatus === "sent"
-                  ? "RSVP Sent! ✓"
-                  : "RSVP Now"}
-            </button>
-          </form>
+              <div key={activePersonIndex} className="space-y-3.5 sm:space-y-4 animate-[fadeIn_0.3s_ease-out]">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-gray-900 font-bold mb-1.5 text-sm" style={fontQuicksand}>
+                      First Name <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      required
+                      value={p.firstName}
+                      onChange={(e) => updatePerson(i, "firstName", e.target.value)}
+                      className="w-full px-3 py-2.5 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                      style={fontQuicksand}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-gray-900 font-bold mb-1.5 text-sm" style={fontQuicksand}>
+                      Last Name <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      required
+                      value={p.lastName}
+                      onChange={(e) => updatePerson(i, "lastName", e.target.value)}
+                      className="w-full px-3 py-2.5 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                      style={fontQuicksand}
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-gray-900 font-bold mb-1.5 text-sm" style={fontQuicksand}>
+                      Email <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="email"
+                      required
+                      value={p.email}
+                      onChange={(e) => updatePerson(i, "email", e.target.value)}
+                      className="w-full px-3 py-2.5 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                      style={fontQuicksand}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-gray-900 font-bold mb-1.5 text-sm" style={fontQuicksand}>
+                      Phone <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="tel"
+                      required
+                      value={p.phone}
+                      onChange={(e) => updatePerson(i, "phone", e.target.value)}
+                      className="w-full px-3 py-2.5 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                      style={fontQuicksand}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-gray-900 font-bold mb-2 text-sm" style={fontQuicksand}>
+                    Gender <span className="text-red-500">*</span>
+                  </label>
+                  <div className="flex gap-5">
+                    {["Male", "Female"].map((g) => (
+                      <label key={g} className="flex items-center gap-2 text-sm font-semibold text-gray-800 cursor-pointer" style={fontQuicksand}>
+                        <input
+                          type="radio"
+                          name={`gender-${i}`}
+                          checked={p.gender === g}
+                          onChange={() => updatePerson(i, "gender", g)}
+                          className="w-4 h-4 accent-[#91772F]"
+                        />
+                        {g}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-gray-900 font-bold mb-2 text-sm" style={fontQuicksand}>
+                    Select Activities <span className="text-red-500">*</span>
+                    <span className="block text-gray-500 font-normal text-xs mt-0.5">Tick as many as you'd like</span>
+                  </label>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 bg-gray-50 border-2 border-gray-200 rounded-lg p-3">
+                    {ACTIVITIES.map((activity) => (
+                      <label
+                        key={activity}
+                        className={`flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-200 border-2 ${
+                          p.activities.includes(activity)
+                            ? "bg-[#E4CFB2]/50 border-[#91772F] scale-[1.02]"
+                            : "bg-white border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={p.activities.includes(activity)}
+                          onChange={() => toggleActivity(i, activity)}
+                          className="w-4 h-4 sm:w-5 sm:h-5 accent-[#91772F] flex-shrink-0"
+                        />
+                        <span className="text-sm font-semibold text-gray-800" style={fontQuicksand}>
+                          {activity}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-gray-900 font-bold mb-1.5 text-sm" style={fontQuicksand}>
+                    Medical Concerns <span className="text-gray-500 font-normal">(if any)</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={p.medical}
+                    onChange={(e) => updatePerson(i, "medical", e.target.value)}
+                    className="w-full px-3 py-2.5 text-sm border-2 border-gray-200 rounded-lg focus:border-[#91772F] focus:outline-none transition-colors"
+                    style={fontQuicksand}
+                    placeholder="e.g. asthma, allergies, none"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={addPerson}
+                className="w-full mt-4 flex items-center justify-center gap-2 border-2 border-dashed border-gray-300 rounded-lg py-2.5 text-sm font-bold text-gray-600 hover:border-[#91772F] hover:text-[#91772F] hover:bg-[#91772F]/5 transition-all duration-300"
+                style={fontQuicksand}
+              >
+                <span className="text-lg leading-none">+</span> Add Another Person
+              </button>
+
+              <div className="mt-4 flex items-start gap-2.5">
+                <input
+                  type="checkbox"
+                  checked={dataProtectionAccepted}
+                  onChange={(e) => setDataProtectionAccepted(e.target.checked)}
+                  className="mt-1 w-4 h-4 sm:w-5 sm:h-5 accent-[#91772F] flex-shrink-0"
+                />
+                <p className="text-sm font-medium text-gray-800" style={fontQuicksand}>
+                  I accept your{" "}
+                  <button
+                    type="button"
+                    onClick={() => setShowDataProtection(true)}
+                    className="text-[#742F8D] font-bold underline"
+                  >
+                    Data Protection Statement
+                  </button>
+                </p>
+              </div>
+
+              {error && (
+                <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg animate-[fadeIn_0.3s_ease-out]">
+                  <p className="text-red-600 font-semibold text-xs sm:text-sm" style={fontQuicksand}>{error}</p>
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={submitStatus === "sending" || submitStatus === "sent"}
+                className="w-full mt-4 bg-gradient-to-r from-[#1F1591] to-[#742F8D] text-white px-6 py-3 rounded-lg font-bold text-sm sm:text-base transition-all duration-300 hover:shadow-lg hover:scale-[1.02] disabled:opacity-60 disabled:hover:scale-100"
+                style={fontQuicksand}
+              >
+                {submitStatus === "sending"
+                  ? "Submitting..."
+                  : submitStatus === "sent"
+                  ? "Sign Up Received! ✓"
+                  : "Proceed »"}
+              </button>
+            </form>
+          </div>
         </div>
       </section>
 
-      {/* Back to Home */}
-      <section className="py-8 sm:py-10 bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80]">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
-          <h2
-            className="text-lg sm:text-xl font-bold text-white mb-3"
-            style={fontLeague}
+      {/* Data Protection Modal */}
+      {showDataProtection && (
+        <div
+          className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50 animate-[fadeIn_0.2s_ease-out]"
+          onClick={() => setShowDataProtection(false)}
+        >
+          <div
+            className="bg-white rounded-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto p-5 sm:p-6"
+            onClick={(e) => e.stopPropagation()}
           >
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg sm:text-xl font-bold text-[#1F1591]" style={fontLeague}>
+                Data Protection Statement
+              </h3>
+              <button onClick={() => setShowDataProtection(false)} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">
+                ×
+              </button>
+            </div>
+            <div className="text-sm text-gray-700 space-y-4 leading-relaxed" style={fontQuicksand}>
+              <p>
+                Keeping your data secure is very important to us. By providing your personal details you agree to allow Partakers Manchester (RCCG Precious People Parish) to contact you either on the basis of the consent you have given us or for our legitimate interests, in accordance with current data protection regulations. We will never make your personal data available for marketing purposes to external individuals or organisations. For more information, email <a href="mailto:partakersppp@gmail.com" className="text-[#742F8D] underline font-semibold">partakersppp@gmail.com</a>.
+              </p>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">How we collect information about you</p>
+                <p>We collect personal information each time you are in contact with us. For example, when you sign up for an event, make a donation, book onto a programme, request a resource, or send us an email.</p>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">Why we collect information about you</p>
+                <p>We collect information about you for the following reasons:</p>
+                <ul className="list-disc pl-5 mt-1 space-y-1">
+                  <li>To provide you with information about events and resources, tailored to your interests.</li>
+                  <li>To process donations you give us and ensure they are recorded correctly.</li>
+                  <li>To keep records of your relationship with us, for example events you've attended or enquiries you've made.</li>
+                  <li>To enhance or improve your experience on our website and better meet your needs.</li>
+                </ul>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">Keeping us up to date with your details and contact preferences</p>
+                <p>Please tell us as soon as any of your contact details change so we can keep our records up to date. You can change how we contact you, or the kind of material we send you, at any time by contacting us by phone or email using the details above. You can unsubscribe from our regular emails at any time using the "unsubscribe" link on the email you receive.</p>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">Who sees your information?</p>
+                <p>The information we collect is used exclusively within Partakers Manchester. We do not pass any of your personal information to any other organisations and/or individuals without your express consent.</p>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">Our use of your information</p>
+                <p>By providing information you are agreeing to receive communications about the work of Partakers Manchester. Each time you receive an email, you will be able to update your preferences and subscribe or unsubscribe from regular emails.</p>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">How long do we keep your information?</p>
+                <p>The length of time we keep the information you have given us depends on the context in which you provided it. We will only keep information that is necessary for event coordination, pastoral care, and for statistical purposes.</p>
+              </div>
+
+              <div>
+                <p className="font-bold text-[#1F1591] mb-1">Viewing the information we hold about you</p>
+                <p>You may request details of all the information Partakers Manchester holds about you by submitting a written request to: Partakers Manchester, Precious House, 6 Harthill Street, Manchester M8 8AG.</p>
+              </div>
+
+              <p className="text-xs text-gray-500 pt-2 border-t border-gray-100">
+                This is our current Data Protection Statement, updated 2026. Please refer to this statement when necessary.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Back */}
+      <section className="py-6 sm:py-8 bg-gradient-to-r from-[#1F1591] via-[#742F8D] to-[#1D4C80]">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+          <h2 className="text-base sm:text-xl font-bold text-white mb-3" style={fontLeague}>
             Can't wait to see you there!
           </h2>
           <button


### PR DESCRIPTION
feat: add Sports Day event page and site-wide announcement bar

Sports Day page (src/pages/events/SportsDay.jsx)
- Build full event page with hero, key details card, about/activities
  section, and multi-person sign-up form
- Support multi-select activity checkboxes (11 activities) instead of
  single choice, allowing sign-ups for more than one activity
- Add multi-person sign-up flow with person chips and clear "Now
  filling in: Person X" indicator to avoid confusion when adding people
- Add Data Protection Statement modal, adapted for Partakers Manchester
- Fix submit button getting stuck on "Sign Up Received!" by resetting
  submitStatus after confirmation delay
- Bold/highlight date, time, and location; convert maps link to a
  proper CTA button
- Rewrite event description and tagline to reflect this being the
  first-ever Partakers Sports Day
- Tighten spacing and add subtle fade/scale animations throughout
- Make fully responsive across mobile/tablet/desktop

Backend (sports day signup)
- Add /api/sports-day-rsvp POST route: validates payload, saves each
  signup to MongoDB via Mongoose, and emails a styled summary to the
  church inbox via Nodemailer
- Add /api/sports-day-rsvp GET route to list stored signups
- Fix missing mongoose.connect() call causing insertMany() to hang/
  timeout
- Fix incorrect env var (EMAIL_USER1 -> EMAIL_USER) in email recipient
- Restyle signup notification email with table layout for readability

Announcement bar (src/components/AnnouncementBar.jsx)
- Add dismissible announcement bar for Sports Day registration, linking to
  /events/sports-day
- Render in normal document flow (not fixed) to sit flush above Navbar
  with no layout gap

Navbar (src/components/Navbar.jsx)
- Fix broken "Get In Touch" link (/contact-us -> /contact)